### PR TITLE
adding test AB1 modal open/close on homepage

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -40,7 +40,7 @@
 
 	<script type="text/javascript">(function(f,b){if(!b.__SV){var a,e,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
 for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=f.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=f.getElementsByTagName("script")[0];e.parentNode.insertBefore(a,e)}})(document,window.mixpanel||[]);
-mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script><!--fa1cf03ade09c3fe61c767b3102e5eb7-->
+mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script>
 
 	<script>(function() {
 		var _fbq = window._fbq || (window._fbq = []);
@@ -266,6 +266,19 @@ mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script><!--fa1cf03ade09c3fe6
 		    return vars;
 		}
 		mixpanel.track("Page Loaded", {"Page Name": "Home", "Page Source": page_source });
+		//
+		// track A/B tests
+		$(function() {
+			var test = "";
+		 	var test_id = 1 % Math.ceil(2 * Math.random());
+			if (test_id) {
+				mixpanel.track("AB Tests", {"Version": "A", "Tested": "AB1" });
+			} else {
+				mixpanel.track("AB Tests", {"Version": "B", "Tested": "AB1" });
+				//open modal if Version B is served
+				F4_CTA_modal('open');
+			}
+		});
 		//
 		// track page load and source
 		mixpanel.track_links(".mixpanel-newsletter_header", "Newsletter - clicked", {"Position": "header"});


### PR DESCRIPTION
Adding event to mixpanel: mixpanel.track("AB Tests", {"Version": "A", "Tested": "AB1" });

We can see which version was served and which test it contained. If B is served the modal will be faded in by default. A is as is, modal only visible when scrolling down.