### PR TITLE
Fix license typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of fake nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 


### PR DESCRIPTION
"fake" should be "the copyright holder"

Reference: http://opensource.org/licenses/BSD-3-Clause