### PR TITLE
fixing css bug mobile: section newsletter headline too long

### DIFF
--- a/static/html/become-an-ambassador.hbs
+++ b/static/html/become-an-ambassador.hbs
@@ -122,6 +122,7 @@ mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script><!--T:bf14c79a96fff9b
 			</div><!--//section_video -->
 			<div class="section_mood"><!--//yeay!!!! --></div><!--//section_mood -->
 			<div class="section_newsletter">
+				<br />
 				<img src="assets/images/index_section_newsletter_headline.png" />
 				<p>
 					Sign up for our newsletter and become someone’s superhero.<br />

--- a/static/html/index.hbs
+++ b/static/html/index.hbs
@@ -435,7 +435,8 @@
 				</ul>
 			</div><!--//section_press -->
 			<div class="section_newsletter">
-				<img src="assets/images/index_section_newsletter_headline.png" style="display: block; margin: 0 auto 0 auto; height: 134px; padding: 40px 0 0 0;" />
+				<br />
+				<img src="assets/images/index_section_newsletter_headline.png" />
 				<p>
 					Sign up for our newsletter and become someone’s superhero.<br />
 					Every 50th email will win a Jewelbot - and we will donate another to <a href="https://www.scripted.org/" target="_blank">ScriptEd</a>.

--- a/static/scss/style_v5.css
+++ b/static/scss/style_v5.css
@@ -2718,9 +2718,10 @@ body {}
 		display: block;
 		position: relative;
 		width: auto;
-		height: 100px;
+		height: auto;
+		max-width: 90%;
 		margin: 0 auto 0 auto;
-		padding: 40px 15px 0 15px;
+		padding: 0 15px 0 15px;
 	}
 	#site_container.index .section_newsletter p {}
 	#site_container.index .section_newsletter p a {}
@@ -4289,7 +4290,7 @@ body {}
 	width: auto;
 	height: 146px;
 	margin: 0 auto 0 auto;
-	padding: 40px 15px 0 15px;
+	padding: 40px 0 0 0;
 }
 #site_container.ambassador .section_newsletter p {
 	display: block;
@@ -4445,9 +4446,10 @@ body {}
 		display: block;
 		position: relative;
 		width: auto;
-		height: 100px;
+		height: auto;
+		max-width: 90%;
 		margin: 0 auto 0 auto;
-		padding: 40px 15px 0 15px;
+		padding: 40px 0 0 0;
 	}
 	#site_container.ambassador .section_newsletter p {}
 	#site_container.ambassador .section_newsletter p a {}


### PR DESCRIPTION
BUG:
- on mobile headline of newsletter section runs too long, causes site to have a white bar on the right

ISSUE:
- breakpoint was set for older, shorter headline

SOLUTION:
- updating break point values