### PR TITLE
new ladningpage for buy2, get 3 campaign

### DIFF
--- a/static/html/buy2.hbs
+++ b/static/html/buy2.hbs
@@ -4440,7 +4440,7 @@
 		<div id="content_container">
 			<div class="section_header">
 				<div class="header_default"><!-- //header_default //header_default_nav //header_sticky-->
-					<a href="/index.html" target="_self" onClick="mixpanel.track('INTERACTION', {'ACTION': 'clicked_home', 'POSITION': 'header'});">
+					<a href="/buy2.html" target="_self" onClick="mixpanel.track('INTERACTION', {'ACTION': 'clicked_home', 'POSITION': 'header'});">
 						<img class="logo_icon_small" src="assets/images/index_section_header__icon_small.png" />
 						<img class="logo_icon_large" src="assets/images/index_section_header__icon_large.png" />
 						<img class="logo_wordmark" src="assets/images/index_section_header__wordmark.png" />


### PR DESCRIPTION
- prevent people from reaching landing page (A) from landing page (B) directly.