### PR TITLE
fixes 'devies' typo and removes '<<<HEAD<<<' text from merge conflict

### DIFF
--- a/static/html/go.hbs
+++ b/static/html/go.hbs
@@ -342,7 +342,7 @@ mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script><!--T:bf14c79a96fff9b
 								<p>It should light up with all white LEDs (LEDs are lights!). Also, remember it's 3 full seconds (1 mississippi...2 mississippi...)! </p>
 
 							<h3><span>3. </span>Have a friend’s jewelbots within two feet of you also in Pairing Mode.</h3>
-								<p> When both devies have found each other in pairing mode, they will start cycling through single colors.</p>
+								<p> When both devices have found each other in pairing mode, they will start cycling through single colors.</p>
 
 							<h3><span>4. </span>Choose a Friendship Color! Make each friend unique by picking different colors.</h3>
 								<p>The Jewelbot will cycle through 4 colors that are your Friendship Color options.</p>
@@ -416,12 +416,7 @@ mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script><!--T:bf14c79a96fff9b
 				</div>
 				<div class="instructions">
 					<div class="copy">
-<<<<<<< HEAD
 						<p>Before coding, we strongly urge you to make sure you updated your firmware first!!! This is to ensure minimal bugs and gives you the newest features. Please refer to the "How to update your Firmware" section.</p>
-=======
-						<p>Before coding, you have to updated your firmware first!!! This is to ensure minimal bugs and gives you the newest features. Please refer to the "How to update your Firmware" section.</p>
->>>>>>> go_page
-
 						<h3><span>1. </span>Install the Arduino Software (IDE)</h3>
 							<p>a. <a href="https://www.arduino.cc/en/Guide/Windows" target="_blank">Windows</a>
 							<br>b. <a href="https://www.arduino.cc/en/Guide/MacOSX" target="_blank">Mac OS X</a></p>


### PR DESCRIPTION
Hi! I'm submitting this PR to fix two minor issues on the go page.

- a small typo in the pairing instructions: 'devies' should be 'devices'
- a '<<<<HEAD<<<' tag from a merge conflict made it on the page.
 
I wasn't totally sure which text you wanted from the HEAD tag. So I went with the one I thought you wanted. Screenshots of the issues are below.

![screen shot 2016-11-30 at 2 27 46 pm](https://cloud.githubusercontent.com/assets/4818182/20772528/0fabc00c-b70b-11e6-8c38-730a5cec447f.png)

![screen shot 2016-11-30 at 2 40 25 pm](https://cloud.githubusercontent.com/assets/4818182/20772536/1abf6cf0-b70b-11e6-872b-58320fe4710c.png)


Let me know if there's anything else I can do! And thanks for the great instructions! Super helpful!
