### PR TITLE
fixes <<<<HEAD text from conflict on go.hbs

### DIFF
--- a/static/html/go.hbs
+++ b/static/html/go.hbs
@@ -480,10 +480,7 @@ mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script><!--T:bf14c79a96fff9b
 							<p> The int section can be from 0-3, basic
 									colors are available, and time is in milliseconds.
 							</p>
-<<<<<<< HEAD
-=======
 
->>>>>>> go_page
  					<h3><span>10. </span> Learn more about coding your Jewelbot here on the <a href="http://alpha.jewelbots.com/" target="_blank">forums!</a></h3>
 
 					</div><!--//copy -->


### PR DESCRIPTION
I think I accidentally left this out of the previous PR.
![screen shot 2016-11-30 at 3 47 02 pm](https://cloud.githubusercontent.com/assets/4818182/20774620/5c1b7050-b714-11e6-890c-c0dae171e47a.png)

It is now removed for real. Sorry about that.