### PR TITLE
correct instsalled to installed

### DIFF
--- a/static/html/go.hbs
+++ b/static/html/go.hbs
@@ -423,7 +423,7 @@ mixpanel.init("9de67913ff56693e76306919cc0fe64e");</script><!--T:bf14c79a96fff9b
 							<p>Ardunio Software (IDE) is a program that allows you to code your Jewelbot on your computer! </p>
 
 						<h3><span>2. </span>Add the Jewelbot Board to your Arduino IDE</h3>
-							<p>If you already instsalled both of the two Jewelbot boards when updating firmware, then you can skip to step 3. </p>
+							<p>If you already installed both of the two Jewelbot boards when updating firmware, then you can skip to step 3. </p>
 							<p>
 							    	a. From the menu, click "preferences".
 								<br>b. Find the "Additional Boards Manager URL" and add the following: https://jewelbots.github.io/arduino-library/package_jewelbots_index.json,https://jewelbots.github.io/arduino-firmware/package_jewelbots_firmware_index.json </li>


### PR DESCRIPTION
Installed was misspelled in the Install the Arduino Software (IDE) section. This commit corrrects it.